### PR TITLE
adding minimal ipython notebooks to the first 3 examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/.ipynb_checkpoints/

--- a/pysrc/example1/example1.ipynb
+++ b/pysrc/example1/example1.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A demo program to show how a TAP query in PyVO works. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyvo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# you can skip running this cell if you're interested in the warnings\n",
+    "import warnings\n",
+    "warnings.simplefilter(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TAP service object\n",
+    "service = pyvo.dal.TAPService (\"http://dc.zah.uni-heidelberg.de/tap\")\n",
+    "# ADQL query job& result \n",
+    "result = service.search (\"SELECT TOP 1 * FROM ivoa.obscore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# view of the FIELDs (columns) of the result (XML snippets)\n",
+    "result.fielddescs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# visual inspection of the result table\n",
+    "result.table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# saving the full VOTable (XML) locally\n",
+    "result.votable.to_xml(\"result.vot\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pysrc/example2/example2.ipynb
+++ b/pysrc/example2/example2.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A demo program to show as simple Cone Search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyvo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query the ConeSearch service at RA=43, Dec=35 degrees with a 3 degrees search radius\n",
+    "service=pyvo.dal.SCSService(\"http://vo.km3net.de/ant20_01/nu/cone/scs.xml?\")\n",
+    "neutrinos=service.search(pos=(43,35), radius=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# results table FIELDs (columns) descriptions (XML snippets)\n",
+    "neutrinos.fielddescs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visual inspection of the result's table\n",
+    "neutrinos.table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Saving (locally) the VOTable\n",
+    "neutrinos.votable.to_xml(\"neutrinos.xml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Broadcasting the Table to TOPCAT \n",
+    "# (if open, otherwise it's throw an Error)\n",
+    "neutrinos.broadcast_samp(\"topcat\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pysrc/example3/example3.ipynb
+++ b/pysrc/example3/example3.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A demo program to query an ObsTAP service with local positions\n",
+    "It uses the previously retrieved neutrino event positions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.table import Table\n",
+    "import pyvo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import warnings\n",
+    "\n",
+    "if not sys.warnoptions:\n",
+    "    warnings.simplefilter(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ADQL query with JOIN on local table and positional crossmatch\n",
+    "QUERY=\"\"\"\n",
+    "SELECT\n",
+    "   TOP 50\n",
+    "   *\n",
+    "   FROM ivoa.obscore AS db\n",
+    "   JOIN TAP_UPLOAD.lt AS mine\n",
+    "   ON 1=CONTAINS (POINT('ICRS', db.s_ra, db.s_dec),\n",
+    "                 CIRCLE('ICRS', mine.RA, mine.Decl, mine.Beta))\n",
+    "   AND db.dataproduct_type='image'\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Try to load neutrino file from example2 \n",
+    "try:\n",
+    "  lt = Table.read('../example2/neutrinos.vot', format='votable')\n",
+    "\n",
+    "# Or get the fallback file\n",
+    "except: \n",
+    "  lt = Table.read('fallback.vot', format='votable')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make Service Object\n",
+    "service = pyvo.dal.TAPService (\"http://dc.zah.uni-heidelberg.de/tap\")\n",
+    "\n",
+    "# Run Search on obscore table on the GAVO dc\n",
+    "result = service.run_async(query=QUERY, uploads={\"lt\":lt})\n",
+    "\n",
+    "# Send resulting table to Topcat via SAMP\n",
+    "result.broadcast_samp(\"topcat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See *examples 1 & 2* for commands to inspect the **result** table here."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
I *created* (strong for copy/pasted into) ipython notebooks out of the first three examples' python scripts.
They were used to teach an online university lecture.

I added a .gitignore to the repo to avoid loading into it the _.ipynb_checkpoints_ in case this PR gets merged and used in future updates/upgrade of the tutorial.